### PR TITLE
Fixes for 5.0 changes to FHitResult

### DIFF
--- a/GASShooter.uproject
+++ b/GASShooter.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.27",
+	"EngineAssociation": "5.0",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/Source/GASShooter/Private/Characters/Abilities/AbilityTasks/GSAT_WaitInteractableTarget.cpp
+++ b/Source/GASShooter/Private/Characters/Abilities/AbilityTasks/GSAT_WaitInteractableTarget.cpp
@@ -21,7 +21,7 @@ UGSAT_WaitInteractableTarget* UGSAT_WaitInteractableTarget::WaitForInteractableT
 	MyObj->MaxRange = MaxRange;
 	MyObj->TimerPeriod = TimerPeriod;
 	MyObj->bShowDebug = bShowDebug;
-	
+
 	AGSHeroCharacter* Hero = Cast<AGSHeroCharacter>(OwningAbility->GetCurrentActorInfo()->AvatarActor);
 
 	MyObj->StartLocation1P = FGameplayAbilityTargetingLocationInfo();
@@ -66,11 +66,12 @@ void UGSAT_WaitInteractableTarget::LineTrace(FHitResult& OutHitResult, const UWo
 	for (int32 HitIdx = 0; HitIdx < HitResults.Num(); ++HitIdx)
 	{
 		const FHitResult& Hit = HitResults[HitIdx];
+		const AActor* HitActor = Hit.GetActor();
 
-		if (!Hit.Actor.IsValid() || Hit.Actor != Ability->GetCurrentActorInfo()->AvatarActor.Get())
+		if (!HitActor || HitActor != Ability->GetCurrentActorInfo()->AvatarActor.Get())
 		{
 			// If bLookForInteractableActor is false, we're looking for an endpoint to trace to
-			if (bLookForInteractableActor && Hit.Actor.IsValid())
+			if (bLookForInteractableActor && HitActor)
 			{
 				// bLookForInteractableActor is true, hit component must overlap COLLISION_INTERACTABLE trace channel
 				// This is so that a big Actor like a computer can have a small interactable button.
@@ -78,9 +79,9 @@ void UGSAT_WaitInteractableTarget::LineTrace(FHitResult& OutHitResult, const UWo
 					== ECollisionResponse::ECR_Overlap)
 				{
 					// Component/Actor must be available to interact
-					bool bIsInteractable = Hit.Actor.Get()->Implements<UGSInteractable>();
+					bool bIsInteractable = HitActor->Implements<UGSInteractable>();
 
-					if (bIsInteractable && IGSInteractable::Execute_IsAvailableForInteraction(Hit.Actor.Get(), Hit.Component.Get()))
+					if (bIsInteractable && IGSInteractable::Execute_IsAvailableForInteraction(HitActor, Hit.Component.Get()))
 					{
 						OutHitResult = Hit;
 						OutHitResult.bBlockingHit = true; // treat it as a blocking hit
@@ -215,7 +216,7 @@ void UGSAT_WaitInteractableTarget::PerformTrace()
 
 	FHitResult ReturnHitResult;
 	LineTrace(ReturnHitResult, GetWorld(), TraceStart, TraceEnd, TraceProfile.Name, Params, true);
-	
+
 	// Default to end of trace line if we don't hit a valid, available Interactable Actor
 	// bBlockingHit = valid, available Interactable Actor
 	if (!ReturnHitResult.bBlockingHit)
@@ -223,7 +224,7 @@ void UGSAT_WaitInteractableTarget::PerformTrace()
 		// No valid, available Interactable Actor
 
 		ReturnHitResult.Location = TraceEnd;
-		if (TargetData.Num() > 0 && TargetData.Get(0)->GetHitResult()->Actor.Get())
+		if (TargetData.Num() > 0 && TargetData.Get(0)->GetHitResult()->GetActor())
 		{
 			// Previous trace had a valid Interactable Actor, now we don't have one
 			// Broadcast last valid target
@@ -240,9 +241,9 @@ void UGSAT_WaitInteractableTarget::PerformTrace()
 
 		if (TargetData.Num() > 0)
 		{
-			const AActor* OldTarget = TargetData.Get(0)->GetHitResult()->Actor.Get();
+			const AActor* OldTarget = TargetData.Get(0)->GetHitResult()->GetActor();
 
-			if (OldTarget == ReturnHitResult.Actor.Get())
+			if (OldTarget == ReturnHitResult.GetActor())
 			{
 				// Old target is the same as the new target, don't broadcast the target
 				bBroadcastNewTarget = false;
@@ -267,7 +268,7 @@ void UGSAT_WaitInteractableTarget::PerformTrace()
 	if (bShowDebug)
 	{
 		DrawDebugLine(GetWorld(), TraceStart, TraceEnd, FColor::Green, false, TimerPeriod);
-		
+
 		if (ReturnHitResult.bBlockingHit)
 		{
 			DrawDebugSphere(GetWorld(), ReturnHitResult.Location, 20.0f, 16, FColor::Red, false, TimerPeriod);

--- a/Source/GASShooter/Private/Characters/Abilities/GSGATA_SphereTrace.cpp
+++ b/Source/GASShooter/Private/Characters/Abilities/GSGATA_SphereTrace.cpp
@@ -79,8 +79,9 @@ void AGSGATA_SphereTrace::SphereTraceWithFilter(TArray<FHitResult>& OutHitResult
 	for (int32 HitIdx = 0; HitIdx < HitResults.Num(); ++HitIdx)
 	{
 		FHitResult& Hit = HitResults[HitIdx];
+		const AActor* HitActor = Hit.GetActor();
 
-		if (!Hit.Actor.IsValid() || FilterHandle.FilterPassesForActor(Hit.Actor))
+		if (!HitActor || FilterHandle.FilterPassesForActor(HitActor))
 		{
 			Hit.TraceStart = TraceStart;
 			Hit.TraceEnd = End;

--- a/Source/GASShooter/Private/Characters/Abilities/GSGATA_Trace.cpp
+++ b/Source/GASShooter/Private/Characters/Abilities/GSGATA_Trace.cpp
@@ -65,7 +65,7 @@ void AGSGATA_Trace::SetShouldProduceTargetDataOnServer(bool bInShouldProduceTarg
 
 void AGSGATA_Trace::SetDestroyOnConfirmation(bool bInDestroyOnConfirmation)
 {
-	bDestroyOnConfirmation = bInDestroyOnConfirmation;
+	bDestroyOnConfirmation = bDestroyOnConfirmation;
 }
 
 void AGSGATA_Trace::StartTargeting(UGameplayAbility* Ability)
@@ -191,8 +191,9 @@ void AGSGATA_Trace::LineTraceWithFilter(TArray<FHitResult>& OutHitResults, const
 	for (int32 HitIdx = 0; HitIdx < HitResults.Num(); ++HitIdx)
 	{
 		FHitResult& Hit = HitResults[HitIdx];
+		const AActor* HitActor = Hit.GetActor();
 
-		if (!Hit.Actor.IsValid() || FilterHandle.FilterPassesForActor(Hit.Actor))
+		if (!HitActor || FilterHandle.FilterPassesForActor(HitActor))
 		{
 			Hit.TraceStart = TraceStart;
 			Hit.TraceEnd = End;
@@ -352,8 +353,9 @@ TArray<FHitResult> AGSGATA_Trace::PerformTrace(AActor* InSourceActor)
 		for (int32 i = PersistentHitResults.Num() - 1; i >= 0; i--)
 		{
 			FHitResult& HitResult = PersistentHitResults[i];
+			const AActor* HitActor = HitResult.GetActor();
 
-			if (HitResult.bBlockingHit || !HitResult.Actor.IsValid() || FVector::DistSquared(TraceStart, HitResult.Actor.Get()->GetActorLocation()) > (MaxRange * MaxRange))
+			if (HitResult.bBlockingHit || !HitActor || FVector::DistSquared(TraceStart, HitActor->GetActorLocation()) > (MaxRange * MaxRange))
 			{
 				PersistentHitResults.RemoveAt(i);
 			}
@@ -385,13 +387,14 @@ TArray<FHitResult> AGSGATA_Trace::PerformTrace(AActor* InSourceActor)
 			}
 
 			FHitResult& HitResult = TraceHitResults[j];
+			const AActor* HitActor = HitResult.GetActor();
 
 			// Reminder: if bUsePersistentHitResults, Number of Traces = 1
 			if (bUsePersistentHitResults)
 			{
 				// This is looping backwards so that further objects from player are added first to the queue.
 				// This results in closer actors taking precedence as the further actors will get bumped out of the TArray.
-				if (HitResult.Actor.IsValid() && (!HitResult.bBlockingHit || PersistentHitResults.Num() < 1))
+				if (HitActor && (!HitResult.bBlockingHit || PersistentHitResults.Num() < 1))
 				{
 					bool bActorAlreadyInPersistentHits = false;
 
@@ -400,7 +403,7 @@ TArray<FHitResult> AGSGATA_Trace::PerformTrace(AActor* InSourceActor)
 					{
 						FHitResult& PersistentHitResult = PersistentHitResults[k];
 
-						if (PersistentHitResult.Actor.Get() == HitResult.Actor.Get())
+						if (PersistentHitResult.GetActor() == HitActor)
 						{
 							bActorAlreadyInPersistentHits = true;
 							break;
@@ -429,13 +432,13 @@ TArray<FHitResult> AGSGATA_Trace::PerformTrace(AActor* InSourceActor)
 				{
 					if (AGameplayAbilityWorldReticle* LocalReticleActor = ReticleActors[ReticleIndex].Get())
 					{
-						const bool bHitActor = HitResult.Actor != nullptr;
+						const bool bHitActor = HitActor != nullptr;
 
 						if (bHitActor && !HitResult.bBlockingHit)
 						{
 							LocalReticleActor->SetActorHiddenInGame(false);
 
-							const FVector ReticleLocation = (bHitActor && LocalReticleActor->bSnapToTargetedActor) ? HitResult.Actor->GetActorLocation() : HitResult.Location;
+							const FVector ReticleLocation = (bHitActor && LocalReticleActor->bSnapToTargetedActor) ? HitActor->GetActorLocation() : HitResult.Location;
 
 							LocalReticleActor->SetActorLocation(ReticleLocation);
 							LocalReticleActor->SetIsTargetAnActor(bHitActor);
@@ -492,19 +495,20 @@ TArray<FHitResult> AGSGATA_Trace::PerformTrace(AActor* InSourceActor)
 		for (int32 PersistentHitResultIndex = 0; PersistentHitResultIndex < PersistentHitResults.Num(); PersistentHitResultIndex++)
 		{
 			FHitResult& HitResult = PersistentHitResults[PersistentHitResultIndex];
+			const AActor* HitActor = HitResult.GetActor();
 
 			// Update TraceStart because old persistent HitResults will have their original TraceStart and the player could have moved since then
 			HitResult.TraceStart = StartLocation.GetTargetingTransform().GetLocation();
 
 			if (AGameplayAbilityWorldReticle* LocalReticleActor = ReticleActors[PersistentHitResultIndex].Get())
 			{
-				const bool bHitActor = HitResult.Actor != nullptr;
+				const bool bHitActor = HitActor != nullptr;
 
 				if (bHitActor && !HitResult.bBlockingHit)
 				{
 					LocalReticleActor->SetActorHiddenInGame(false);
 
-					const FVector ReticleLocation = (bHitActor && LocalReticleActor->bSnapToTargetedActor) ? HitResult.Actor->GetActorLocation() : HitResult.Location;
+					const FVector ReticleLocation = (bHitActor && LocalReticleActor->bSnapToTargetedActor) ? HitActor->GetActorLocation() : HitResult.Location;
 
 					LocalReticleActor->SetActorLocation(ReticleLocation);
 					LocalReticleActor->SetIsTargetAnActor(bHitActor);


### PR DESCRIPTION
Apparently FHitResult no longer has an actor field and requires the use of new method GetActor().  Tested working on 5.0 EA and 5.0.