### PR TITLE
Added b prefix to bool variable

### DIFF
--- a/Source/GASShooter/Private/Characters/Abilities/GSGameplayAbility.cpp
+++ b/Source/GASShooter/Private/Characters/Abilities/GSGameplayAbility.cpp
@@ -39,7 +39,7 @@ void UGSGameplayAbility::OnAvatarSet(const FGameplayAbilityActorInfo* ActorInfo,
 
 	if (bActivateAbilityOnGranted)
 	{
-		bool ActivatedAbility = ActorInfo->AbilitySystemComponent->TryActivateAbility(Spec.Handle, false);
+		bool bActivatedAbility = ActorInfo->AbilitySystemComponent->TryActivateAbility(Spec.Handle, false);
 	}
 }
 


### PR DESCRIPTION
Added b prefix to bool variable so it conforms with my typos-fixed branch PR and with [Epic coding standards](https://docs.unrealengine.com/en-US/epic-cplusplus-coding-standard-for-unreal-engine/#namingconventions)